### PR TITLE
Fix apache ec2

### DIFF
--- a/controller/src/TrainingWheels/Plugin/ApacheHTTPD/ApacheHTTPD.php
+++ b/controller/src/TrainingWheels/Plugin/ApacheHTTPD/ApacheHTTPD.php
@@ -13,10 +13,6 @@ class ApacheHTTPD extends PluginBase {
   public function getAnsibleConfig() {
     return array(
       'vars' => array(
-        'apache_server_admin' => 'webmaster@training.wheels',
-        'apache_server_alias' => '*.*.training.wheels',
-        'apache_servername' => 'training.wheels',
-
         # apache virtual document roots, these two are closely related.
         # Note that the -4 and -3 correspond to the number of segments
         # in the domain name you choose above. So /twhome/%-4/%-3 results

--- a/controller/src/TrainingWheels/Plugin/ApacheHTTPD/ansible/apachehttpd.yml
+++ b/controller/src/TrainingWheels/Plugin/ApacheHTTPD/ansible/apachehttpd.yml
@@ -17,6 +17,13 @@
         - libapache2-mod-php5
 
     ##
+    # Get this server's hostname for use in the Apache config templates.
+    #
+    - name: ApacheHTTPD | Get the current hostname
+      action: shell hostname
+      register: apache_servername
+
+    ##
     # Apache2 setup.
     #
     - name: ApacheHTTPD | Enable rewrite module

--- a/controller/src/TrainingWheels/Plugin/ApacheHTTPD/ansible/templates/etc-apache2-sites-available-trainingwheels.j2
+++ b/controller/src/TrainingWheels/Plugin/ApacheHTTPD/ansible/templates/etc-apache2-sites-available-trainingwheels.j2
@@ -1,7 +1,7 @@
 ServerName {{ apache_servername }}
 <VirtualHost *:80>
-	ServerAdmin {{ apache_server_admin }}
-	ServerAlias {{ apache_server_alias }}
+	ServerAdmin webmaster@{{ apache_servername }}
+	ServerAlias *.*.{{ apache_servername }}
 
 	VirtualDocumentRoot {{ apache_virtual_docroot }}
 

--- a/controller/src/TrainingWheels/Plugin/ApacheHTTPD/ansible/templates/etc-apache2-sites-available-trainingwheels.j2
+++ b/controller/src/TrainingWheels/Plugin/ApacheHTTPD/ansible/templates/etc-apache2-sites-available-trainingwheels.j2
@@ -1,7 +1,7 @@
-ServerName {{ apache_servername }}
+ServerName {{ apache_servername.stdout }}
 <VirtualHost *:80>
-	ServerAdmin webmaster@{{ apache_servername }}
-	ServerAlias *.*.{{ apache_servername }}
+	ServerAdmin webmaster@{{ apache_servername.stdout }}
+	ServerAlias *.*.{{ apache_servername.stdout }}
 
 	VirtualDocumentRoot {{ apache_virtual_docroot }}
 


### PR DESCRIPTION
There is an oversight in the current plugins that hardcoded the vagrant hostname of training.wheels instead of being assigned dynamically in EC2
