### PR TITLE
Don't wait twice for mongo

### DIFF
--- a/playbooks/controller/sample-data.yml
+++ b/playbooks/controller/sample-data.yml
@@ -16,9 +16,6 @@
     - name: Upload sample course data
       action: copy src=mongo-reset-data.js dest=/tmp/mongo-reset-data.js
 
-    - name: MongoDB | Wait for Mongo to be listening for connections. It preallocates some space that takes a while.
-      action: wait_for port=27017 delay=4 timeout=$mongo_restart_timeout
-
     - name: Insert sample Mongo course data
       action: command mongo -u trainingwheels -p $mongo_app_password trainingwheels /tmp/mongo-reset-data.js
 

--- a/playbooks/controller/sample-data.yml
+++ b/playbooks/controller/sample-data.yml
@@ -16,7 +16,7 @@
     - name: Upload sample course data
       action: copy src=mongo-reset-data.js dest=/tmp/mongo-reset-data.js
 
-    - name: MongoDB | Wait for Mongo to be listening for connections. It preallocates some space that takes a while.
+    - name: MongoDB | Wait for Mongo to be listening for connections. It is restarted as the last step of the controller playbook and can take a while to come up in EC2.
       action: wait_for port=27017 delay=4 timeout=$mongo_restart_timeout
 
     - name: Insert sample Mongo course data

--- a/playbooks/controller/sample-data.yml
+++ b/playbooks/controller/sample-data.yml
@@ -16,6 +16,9 @@
     - name: Upload sample course data
       action: copy src=mongo-reset-data.js dest=/tmp/mongo-reset-data.js
 
+    - name: MongoDB | Wait for Mongo to be listening for connections. It preallocates some space that takes a while.
+      action: wait_for port=27017 delay=4 timeout=$mongo_restart_timeout
+
     - name: Insert sample Mongo course data
       action: command mongo -u trainingwheels -p $mongo_app_password trainingwheels /tmp/mongo-reset-data.js
 

--- a/playbooks/controller/setup.yml
+++ b/playbooks/controller/setup.yml
@@ -161,6 +161,9 @@
     - name: MongoDB | Configure PHP to use PECL MongoDB extension
       action: copy dest=/etc/php5/conf.d/mongo.ini src=files/etc-php5-conf-d-mongo-ini
 
+    - name: MongoDB | Restart Mongo now giving it time to listen for connections before the next playbook.
+      action: service name=mongodb state=restarted
+
     ##
     # Configuration for nginx
     #
@@ -225,6 +228,3 @@
 
     - name: Restart | php-fpm
       action: service name=php5-fpm state=restarted
-
-    - name: Restart | MongoDB
-      action: service name=mongodb state=restarted

--- a/playbooks/controller/setup.yml
+++ b/playbooks/controller/setup.yml
@@ -161,9 +161,6 @@
     - name: MongoDB | Configure PHP to use PECL MongoDB extension
       action: copy dest=/etc/php5/conf.d/mongo.ini src=files/etc-php5-conf-d-mongo-ini
 
-    - name: MongoDB | Restart Mongo now giving it time to listen for connections before the next playbook.
-      action: service name=mongodb state=restarted
-
     ##
     # Configuration for nginx
     #
@@ -228,3 +225,6 @@
 
     - name: Restart | php-fpm
       action: service name=php5-fpm state=restarted
+
+    - name: Restart | MongoDB
+      action: service name=mongodb state=restarted


### PR DESCRIPTION
@elliotttf Was this put in accidentally? I noticed that we wait for mongo to accept connections in the sample data playbook as well as the controller playbook - by the time we reach this one, it will definitely be running and listening, so can safely remove, as currently it always waits 4 seconds.
