### PR TITLE
Expose getResourceVars at the root Resource class.

### DIFF
--- a/controller/src/TrainingWheels/Resource/Resource.php
+++ b/controller/src/TrainingWheels/Resource/Resource.php
@@ -63,4 +63,11 @@ abstract class Resource extends CachedObject {
     );
     return $info;
   }
+
+  /**
+   * Get the configuration options for instances of this resource.
+   */
+  public static function getResourceVars() {
+    return array();
+  }
 }


### PR DESCRIPTION
This was causing a problem with the cloud9 resource since it did not implement this method.
