### PR TITLE
Fix Drupal resource observer bug and ide creation bug

### DIFF
--- a/controller/src/TrainingWheels/Plugin/Drupal/Drupal.php
+++ b/controller/src/TrainingWheels/Plugin/Drupal/Drupal.php
@@ -71,15 +71,17 @@ class Drupal extends PluginBase {
      */
     $course->addObserver('afterUserResourcesCreate', function($data) use ($settings_path, $files_path) {
       $db = $data['user']->resourceGet('drupal_db');
-      $user_name = $data['user']->getName();
-      $course_name = $data['course']->course_name;
+      $gitfiles = $data['user']->resourceGet('drupal_files');
 
-      // @TODO: Make this more flexible, perhaps hand off the replacing to the Gitfiles resource which knows
-      // it's own location.
-      $files_full_path = "/twhome/$user_name/$course_name/" . $files_path;
-      $data['course']->env->dirChmod('g+rwx', $files_full_path);
+      if ($db && $gitfiles && $db->getExists() && $gitfiles->getExists()) {
+        $user_name = $data['user']->getName();
+        $course_name = $data['course']->course_name;
 
-      if ($db && $db->getExists()) {
+        // @TODO: Make this more flexible, perhaps hand off the replacing to the Gitfiles resource which knows
+        // it's own location.
+        $files_full_path = "/twhome/$user_name/$course_name/" . $files_path;
+        $data['course']->env->dirChmod('g+rwx', $files_full_path);
+
         $settings = '\\' . "\$databases['default']['default']['database'] = '" . $db->getDBName() . "';\n";
         $settings .= '\\' . "\$databases['default']['default']['username'] = '" . $db->getUserName() . "';\n";
         $settings .= '\\' . "\$databases['default']['default']['password'] = '" . $db->getPasswd() . "';\n";


### PR DESCRIPTION
This fixes two bugs:
1. The Drupal observer should only do stuff if the resources it needs to act on actually exist, previously, it would attempt to do this stuff when creating a Cloud9IDE resource, for example.
2. Some bugs in the creating / deleting of Supervisor resources.

This pull request should be recreated with master as the target, rather than merging this particular one. The order of merges to master should be:
1. TW-95-ssh-conn
2. **fix-bug-cloud9-res**
3. better-loggin
4. caching
