### PR TITLE
Better logging system that provides a web interface

### DIFF
--- a/controller/README.md
+++ b/controller/README.md
@@ -39,7 +39,7 @@ Console application
 Working with Mongo
 ------------------
 
-To access database CLI, use `mongo -utrainingwheels -ptrainingwheelsApp trainingwheels` on the command line.
+To access database CLI, use `tw mongo:cli` or `tw m:c` on the command line.
 
 Some command examples:
 

--- a/controller/cli/tw.php
+++ b/controller/cli/tw.php
@@ -45,6 +45,8 @@ use TrainingWheels\Console\UserCreate;
 use TrainingWheels\Console\UserDelete;
 use TrainingWheels\Console\UserRetrieve;
 use TrainingWheels\Console\KeyCreate;
+use TrainingWheels\Console\LogClear;
+use TrainingWheels\Console\MongoCLI;
 
 $console = new Application();
 $console->add(new CourseProvision($app['tw.job_factory']));
@@ -55,5 +57,7 @@ $console->add(new ResourceCreate($app['tw.job_factory']));
 $console->add(new ResourceDelete($app['tw.job_factory']));
 $console->add(new ResourceSync($app['tw.job_factory']));
 $console->add(new KeyCreate($app['tw.config']));
+$console->add(new LogClear($app['tw.log']));
+$console->add(new MongoCLI($app['tw.config']));
 
 $console->run();

--- a/controller/src/TrainingWheels/Common/BootstrapServiceProvider.php
+++ b/controller/src/TrainingWheels/Common/BootstrapServiceProvider.php
@@ -15,6 +15,7 @@ use TrainingWheels\Log\Log;
 use TrainingWheels\Store\DataStore;
 use Igorw\Silex\ConfigServiceProvider;
 use Exception;
+use MongoClient;
 
 /**
  * Bootstrap loads the essential Training Wheels components and injects them
@@ -73,12 +74,9 @@ class BootstrapServiceProvider implements ServiceProviderInterface {
       $app['tw.config']['base_path'] = '/var/trainingwheels';
     }
 
-    // We then use the same Monolog instance on the Training Wheels Log object,
-    // so that our application logs all end up in the same place.
-    $app['tw.log'] = new Log($app['monolog']);
-
     // Training Wheels objects.
     $app['tw.datastore'] = new DataStore($app['tw.config']['connections']['mongo']);
+    $app['tw.log'] = new Log($app['monolog'], $app['tw.datastore']);
     $app['tw.course_factory'] = new CourseFactory($app['tw.datastore'], $app['tw.config']);
     $app['tw.job_factory'] = new JobFactory($app['tw.datastore'], $app['tw.course_factory'], $app['tw.config']);
   }

--- a/controller/src/TrainingWheels/Common/Observable.php
+++ b/controller/src/TrainingWheels/Common/Observable.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace TrainingWheels\Common;
+use TrainingWheels\Log\Log;
 use Closure;
 
 class Observable {
@@ -9,6 +10,7 @@ class Observable {
   protected function fireEvent($eventName, array $data = NULL) {
     if (isset($this->observers[$eventName])) {
       foreach ($this->observers[$eventName] as $observer) {
+        Log::log('Calling observer', L_INFO, 'actions', array('layer' => 'app', 'source' => 'Observable', 'params' => "eventName=$eventName"));
         $observer($data);
       }
     }

--- a/controller/src/TrainingWheels/Conn/LocalServerConn.php
+++ b/controller/src/TrainingWheels/Conn/LocalServerConn.php
@@ -10,15 +10,10 @@ class LocalServerConn extends ServerConn {
     // It would be awesome to use the actual return codes, but the SSH server
     // connection plugin doesn't give us those codes, so for compatibility
     // with that plugin, we don't either.
-    Log::log('LocalServerConn::exec: ' . "\n" . $command, L_DEBUG);
     $result = trim(shell_exec($command));
-    Log::log('LocalServerConn::resp: ' . $result, L_DEBUG);
-    Log::log('=====================================================================', L_DEBUG);
-
     if (substr($result, 0, 20) == 'sudo: no tty present') {
       throw new Exception("The current user does not have sudo permission. Check server config or run from console as root");
     }
-
     return $result;
   }
 

--- a/controller/src/TrainingWheels/Conn/SSHServerConn.php
+++ b/controller/src/TrainingWheels/Conn/SSHServerConn.php
@@ -48,10 +48,7 @@ class SSHServerConn extends ServerConn {
 
   protected function exec($command) {
     if ($this->ssh_conn) {
-      Log::log('SSHServerConn::exec: ' . "\n" . $command, L_DEBUG);
       $result = trim($this->ssh_conn->exec($command));
-      Log::log('SSHServerConn::resp: ' . $result, L_DEBUG);
-      Log::log('=====================================================================', L_DEBUG);
       return $result;
     }
     else {

--- a/controller/src/TrainingWheels/Conn/ServerConn.php
+++ b/controller/src/TrainingWheels/Conn/ServerConn.php
@@ -6,10 +6,15 @@ use Exception;
 
 abstract class ServerConn {
 
+  // For logging purposes.
+  private $pretty_commands;
+
   /**
    * Process the commands into a single string.
    */
   protected function process($input) {
+    $this->pretty_commands = array();
+
     if (is_string($input)) {
       $commands = array($input);
     }
@@ -21,6 +26,9 @@ abstract class ServerConn {
     }
 
     foreach ($commands as $key => $command) {
+      // Pretty printing without the redundant info.
+      $this->pretty_commands[] = $command;
+
       // When we run locally, we're running as either the phpfpm user through
       // nginx, or the console. Therefore, we need to add sudo before each call.
       // I've played with many different strategies for chaining together commands
@@ -33,7 +41,7 @@ abstract class ServerConn {
       }
     }
 
-    return implode(' && ' . "\n", $commands);
+    return implode(' && ', $commands);
   }
 
   /**
@@ -47,8 +55,10 @@ abstract class ServerConn {
     }
     $commands[] = "echo 'training_wheels_success'";
     $command = $this->process($commands);
-    $result = $this->exec($command);
+    $message = 'Execute and success';
+    $result = $this->do_exec($command, $message);
     $success = $result == 'training_wheels_success';
+
     if (!$success) {
       throw new Exception('exec_success: One of the commands failed.');
     }
@@ -60,8 +70,9 @@ abstract class ServerConn {
    */
   public function exec_eq($commands, $value = '') {
     $command = $this->process($commands);
-    $result = $this->exec($command);
+    $result = $this->do_exec($command, 'Execute and expect', $value);
     $success = $result == $value;
+
     if (!$success) {
       throw new Exception("exec_eq: The output of the commands failed to return the correct value '$value'.");
     }
@@ -73,7 +84,7 @@ abstract class ServerConn {
    */
   public function exec_get($commands) {
     $command = $this->process($commands);
-    $result = $this->exec($command);
+    $result = $this->do_exec($command, 'Execute and get');
     return $result;
   }
 
@@ -82,11 +93,35 @@ abstract class ServerConn {
    */
   public function exec_starts_with($commands, $value) {
     $command = $this->process($commands);
-    $result = $this->exec($command);
+    $result = $this->do_exec($command, 'Execute starts with', $value);
     $success = substr($result, 0, strlen($value)) == $value;
+
     if (!$success) {
       throw new Exception("exec_starts_with: The output of the commands did not start with the value '$value'.");
     }
     return $success;
+  }
+
+  /**
+   * Execute and get the amount of time it took, plus perform logging.
+   */
+  protected function do_exec($command, $message, $value = '') {
+    $start_time = microtime(TRUE);
+    $result = $this->exec($command);
+    $end_time = microtime(TRUE);
+    $time = $end_time - $start_time;
+
+    $context = array(
+      'layer' => 'env',
+      'source' => 'ServerConn',
+      'commands' => $this->pretty_commands,
+      'result' => $result,
+      'time' => $time,
+      'params' => $value,
+    );
+    Log::log($message, L_DEBUG, 'actions', $context);
+
+    $time = $end_time - $start_time;
+    return $result;
   }
 }

--- a/controller/src/TrainingWheels/Console/CourseProvision.php
+++ b/controller/src/TrainingWheels/Console/CourseProvision.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Exception;
+use stdClass;
 
 class CourseProvision extends Command {
   private $jobFactory;
@@ -26,9 +27,7 @@ class CourseProvision extends Command {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
-    Log::log('CLI command: CourseProvision', L_INFO);
-
-    $job = new \stdClass;
+    $job = new stdClass;
     $job->type = 'course';
     $job->course_id = $input->getArgument('course_id');
     $job->action = 'courseProvision';
@@ -42,6 +41,7 @@ class CourseProvision extends Command {
       $this->jobFactory->remove($job->get('id'));
       throw $e;
     }
+    Log::log('CourseProvision', L_INFO, 'actions', array('layer' => 'user', 'source' => 'CLI', 'params' => 'course_id=' . $job->get('course_id')));
     $output->writeln('<info>Course provisioned.</info>');
   }
 }

--- a/controller/src/TrainingWheels/Console/KeyCreate.php
+++ b/controller/src/TrainingWheels/Console/KeyCreate.php
@@ -24,7 +24,7 @@ class KeyCreate extends Command {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
-    Log::log('CLI command: KeyCreate', L_INFO);
+    Log::log('KeyCreate', L_INFO, 'actions', array('layer' => 'user', 'source' => 'CLI'));
 
     $gen = new KeyManager($this->config['base_path']);
     $output->writeln('');

--- a/controller/src/TrainingWheels/Console/LogClear.php
+++ b/controller/src/TrainingWheels/Console/LogClear.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace TrainingWheels\Console;
+use TrainingWheels\Log\Log;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Exception;
+
+class LogClear extends Command {
+  private $log;
+
+  public function __construct($log) {
+    parent::__construct();
+    $this->log = $log;
+  }
+
+  protected function configure() {
+    $this->setName('log:clear')
+         ->setDescription('Clear the MongoDB logs.');
+  }
+
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    Log::log('LogClear', L_INFO, 'actions', array('layer' => 'user', 'source' => 'CLI'));
+    $this->log->removeDBLogs();
+    $output->writeln('<info>Logs cleared.</info>');
+  }
+}

--- a/controller/src/TrainingWheels/Console/MongoCLI.php
+++ b/controller/src/TrainingWheels/Console/MongoCLI.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace TrainingWheels\Console;
+use TrainingWheels\Log\Log;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Exception;
+
+class MongoCLI extends Command {
+  private $config;
+
+  public function __construct($config) {
+    parent::__construct();
+    $this->config = $config;
+  }
+
+  protected function configure() {
+    $this->setName('mongo:cli')
+         ->setDescription('Drop into a MongoDB CLI authenticated to the TrainingWheels DB.');
+  }
+
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    Log::log('MongoCLI', L_INFO, 'actions', array('layer' => 'user', 'source' => 'CLI'));
+
+    $url_parts = parse_url($this->config['connections']['mongo']);
+    $cmd = 'mongo -u ' . $url_parts['user'] . ' -p ' . $url_parts['pass'] . ' ' . ltrim($url_parts['path'], '/');
+
+    // This code courtesy of drush_shell_proc_open().
+    $process = proc_open($cmd, array(0 => STDIN, 1 => STDOUT, 2 => STDERR), $pipes);
+    $proc_status = proc_get_status($process);
+    $exit_code = proc_close($process);
+    $out = $proc_status["running"] ? $exit_code : $proc_status["exitcode"];
+
+    $output->writeln('<info>MongoDB CLI session ended.</info>');
+  }
+}

--- a/controller/src/TrainingWheels/Console/ResourceCreate.php
+++ b/controller/src/TrainingWheels/Console/ResourceCreate.php
@@ -8,6 +8,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use stdClass;
 
 class ResourceCreate extends Command {
   private $jobFactory;
@@ -27,11 +28,16 @@ class ResourceCreate extends Command {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
-    Log::log('CLI command: ResourceCreate', L_INFO);
     $resources = $input->getArgument('resources');
-    $resources = ($resources == 'all' || empty($resources)) ? array() : explode(',', $resources);
+    $course_id = $input->getArgument('course_id');
+    $user_names = $input->getArgument('user_names');
+    $res_pretty = empty($resources) ? 'all' : $resources;
+    $params = "course_id=$course_id user_names=$user_names resources=" . $res_pretty;
 
-    $job = new \stdClass;
+    Log::log('ResourceCreate', L_INFO, 'actions', array('layer' => 'user', 'source' => 'CLI', 'params' => $params));
+
+    $resources = ($resources == 'all' || empty($resources)) ? array() : explode(',', $resources);
+    $job = new stdClass;
     $job->type = 'resource';
     $job->course_id = $input->getArgument('course_id');
     $job->action = 'resourceCreate';

--- a/controller/src/TrainingWheels/Console/ResourceDelete.php
+++ b/controller/src/TrainingWheels/Console/ResourceDelete.php
@@ -8,6 +8,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use stdClass;
 
 class ResourceDelete extends Command {
   private $jobFactory;
@@ -27,16 +28,21 @@ class ResourceDelete extends Command {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
-    Log::log('CLI command: ResourceDelete', L_INFO);
     $resources = $input->getArgument('resources');
-    $resources = ($resources == 'all' || empty($resources)) ? array() : explode(',', $resources);
+    $course_id = $input->getArgument('course_id');
+    $user_names = $input->getArgument('user_names');
+    $res_pretty = empty($resources) ? 'all' : $resources;
+    $params = "course_id=$course_id user_names=$user_names resources=" . $res_pretty;
 
-    $job = new \stdClass;
+    Log::log('ResourceDelete', L_INFO, 'actions', array('layer' => 'user', 'source' => 'CLI', 'params' => $params));
+
+    $resources = ($resources == 'all' || empty($resources)) ? array() : explode(',', $resources);
+    $job = new stdClass;
     $job->type = 'resource';
-    $job->course_id = $input->getArgument('course_id');
+    $job->course_id = $course_id;
     $job->action = 'resourceDelete';
     $job->params = array(
-      'user_names' => explode(',', $input->getArgument('user_names')),
+      'user_names' => explode(',', $user_names),
       'resources' => $resources,
     );
     $job = $this->jobFactory->save($job);

--- a/controller/src/TrainingWheels/Console/ResourceSync.php
+++ b/controller/src/TrainingWheels/Console/ResourceSync.php
@@ -8,6 +8,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use stdClass;
 
 class ResourceSync extends Command {
   private $jobFactory;
@@ -28,17 +29,23 @@ class ResourceSync extends Command {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
-    Log::log('CLI command: ResourceSync', L_INFO);
     $resources = $input->getArgument('resources');
-    $resources = ($resources == 'all' || empty($resources)) ? array() : explode(',', $resources);
+    $course_id = $input->getArgument('course_id');
+    $source_user = $input->getArgument('source_user');
+    $target_users = $input->getArgument('target_users');
+    $res_pretty = empty($resources) ? 'all' : $resources;
+    $params = "course_id=$course_id source_user=$source_user target_users=$target_users resources=" . $res_pretty;
 
-    $job = new \stdClass;
+    Log::log('ResourceSync', L_INFO, 'actions', array('layer' => 'user', 'source' => 'CLI', 'params' => $params));
+
+    $resources = ($resources == 'all' || empty($resources)) ? array() : explode(',', $resources);
+    $job = new stdClass;
     $job->type = 'resource';
-    $job->course_id = $input->getArgument('course_id');
+    $job->course_id = $course_id;
     $job->action = 'resourceSync';
     $job->params = array(
-      'source_user' => $input->getArgument('source_user'),
-      'target_users' => explode(',', $input->getArgument('target_users')),
+      'source_user' => $source_user,
+      'target_users' => explode(',', $target_users),
       'resources' => $resources,
     );
     $job = $this->jobFactory->save($job);
@@ -51,6 +58,6 @@ class ResourceSync extends Command {
       throw $e;
     }
 
-    $output->writeln('<info>User(s) synced.</info>');
+    $output->writeln('<info>Resource(s) synced.</info>');
   }
 }

--- a/controller/src/TrainingWheels/Console/UserCreate.php
+++ b/controller/src/TrainingWheels/Console/UserCreate.php
@@ -26,10 +26,12 @@ class UserCreate extends Command {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
-    Log::log('CLI command: UserCreate', L_INFO);
-    $course = $this->courseFactory->get($input->getArgument('course_id'));
+    $course_id = $input->getArgument('course_id');
     $user_names = $input->getArgument('user_names');
 
+    Log::log('UserCreate', L_INFO, 'actions', array('layer' => 'user', 'source' => 'CLI', 'params' => 'course_id=' . $course_id . ' users=' . $user_names));
+
+    $course = $this->courseFactory->get($course_id);
     $result = $course->usersCreate(explode(',', $user_names));
     if (!$result) {
       return $output->writeln('<comment>User already exists.</comment>');

--- a/controller/src/TrainingWheels/Console/UserDelete.php
+++ b/controller/src/TrainingWheels/Console/UserDelete.php
@@ -26,10 +26,12 @@ class UserDelete extends Command {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
-    Log::log('CLI command: UserDelete', L_INFO);
-    $course = $this->courseFactory->get($input->getArgument('course_id'));
+    $course_id = $input->getArgument('course_id');
     $user_names = $input->getArgument('user_names');
 
+    Log::log('UserDelete', L_INFO, 'actions', array('layer' => 'user', 'source' => 'CLI', 'params' => 'course_id=' . $course_id . ' users=' . $user_names));
+
+    $course = $this->courseFactory->get($course_id);
     $result = $course->usersDelete(explode(',', $user_names));
     $output->writeln("<info>User(s) deleted.</info>");
   }

--- a/controller/src/TrainingWheels/Console/UserRetrieve.php
+++ b/controller/src/TrainingWheels/Console/UserRetrieve.php
@@ -26,10 +26,12 @@ class UserRetrieve extends Command {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
-    Log::log('CLI command: UserRetrieve', L_INFO);
-    $course = $this->courseFactory->get($input->getArgument('course_id'));
+    $course_id = $input->getArgument('course_id');
     $user_names = $input->getArgument('user_names');
 
+    Log::log('UserRetrieve', L_INFO, 'actions', array('layer' => 'user', 'source' => 'CLI', 'params' => 'course_id=' . $course_id . ' users=' . $user_names));
+
+    $course = $this->courseFactory->get($course_id);
     if ($user_names != 'all') {
       $user_names = explode(',', $user_names);
     }

--- a/controller/src/TrainingWheels/Controller/RESTControllerProvider.php
+++ b/controller/src/TrainingWheels/Controller/RESTControllerProvider.php
@@ -36,6 +36,7 @@ class RESTControllerProvider implements ControllerProviderInterface {
     $parseID = function ($id) use ($app) {
       $parts = explode('-', $id);
       if (isset($parts[0]) && isset($parts[1])) {
+        Log::log('Parse REST request', L_INFO, 'actions', array('layer' => 'user', 'source' => 'Web', 'params' => 'course_id=' . $parts[0] . ' users=' . $parts[1]));
         $course = $app['tw.course_factory']->get($parts[0]);
         return array(
           'course' => $course,

--- a/controller/src/TrainingWheels/Log/Log.php
+++ b/controller/src/TrainingWheels/Log/Log.php
@@ -3,6 +3,7 @@
 namespace TrainingWheels\Log;
 use Monolog\Logger;
 use Monolog\Handler\StreamHandler;
+use Monolog\Handler\MongoDBHandler;
 use Exception;
 
 /**
@@ -16,43 +17,123 @@ define('L_CRITICAL', 4);
 define('L_ALERT', 5);
 
 class Log {
-  protected static $instance = NULL;
-  private $monolog = NULL;
+  protected static $instance;
+  private $main;
+  private $actions;
+  private $data;
 
   /**
    * Constructor.
    */
-  public function __construct($monolog) {
-    $this->monolog = $monolog;
+  public function __construct($main, $data) {
+    // Main log is where Silex is sending it's information to. We have access to that as well
+    // as creating our own MongoDB log entries.
+    $this->main = $main;
+
+    // Add secondary Mongo log streams.
+    $actions_log = new Logger('actions');
+    $actions_handler = new MongoDBHandler($data->getConnection(), 'trainingwheels', 'logs_actions');
+    $actions_log->pushHandler($actions_handler);
+    $this->actions = $actions_log;
+
+    $this->data = $data;
+
     self::$instance = $this;
+  }
+
+  /**
+   * Delete all log entries in the MongoDB store.
+   */
+  public function removeDBLogs() {
+    $this->data->remove('logs_actions', array());
+  }
+
+  /**
+   * Build a page with log entries from a particular stream.
+   */
+  public function renderHTML($stream) {
+    // Sort by microtime.
+    $log_entries = $this->data->findAll('logs_' . $stream, '_id');
+    $output = '<table id="logs-main">';
+
+    $output .= '<thead><tr>';
+    $output .= '<th>Timestamp</th>';
+    $output .= '<th>Source</th>';
+    $output .= '<th>Message</th>';
+    $output .= '<th>Params</th>';
+    $output .= '<th>Commands</th>';
+    $output .= '<th>Result</th>';
+    $output .= '<th>Time</th>';
+    $output .= '</tr></thead>';
+    $output .= '<tbody>';
+
+    foreach ($log_entries as $key => $value) {
+      $source = isset($value->context['source']) ? $value->context['source'] : '';
+      $result = isset($value->context['result']) ? $value->context['result'] : '';
+      $time = isset($value->context['time']) ? round($value->context['time'], 4) : '';
+      $params = isset($value->context['params']) ? $value->context['params'] : '';
+
+      $commands = '';
+      if (isset($value->context['commands'])) {
+        $commands = implode('<br />&gt; ', $value->context['commands']);
+        $commands = '&gt; ' . $commands;
+      }
+
+      $output .= '<tr class="log-row log-layer-' . $value->context['layer'] . ' log-level-' . strtolower($value->level_name) . '">';
+      $output .= '<td class="log-item log-datetime">' . $value->datetime . '</td>';
+      $output .= '<td class="log-item log-source">' . $source . '</td>';
+      $output .= '<td class="log-item log-message log-layer-' . $value->context['layer'] .  '">' . $value->message . '</td>';
+      $output .= '<td class="log-item log-params">' . $params . '</td>';
+      $output .= '<td class="log-item log-commands">' . $commands . '</td>';
+      $output .= '<td class="log-item log-result">' . $result . '</td>';
+      $output .= '<td class="log-item log-time">' . $time . '</td>';
+      $output .= '</tr>';
+    }
+
+    $output .= '</tbody></table>';
+
+    return $output;
   }
 
   /**
    * Static logging method.
    */
-  public static function log($message, $level) {
+  public static function log($message, $level, $stream = 'main', $context = array()) {
     if (!isset(self::$instance)) {
       throw new Exception('Training Wheels Log requires you to create a singleton before calling Log::log()');
     }
     $self = self::$instance;
+
+    if (!isset($self->$stream)) {
+      throw new Exception("Unrecognized log stream \"$stream\"");
+    }
+    $log = $self->$stream;
+
+    // Log message layer. We define three layers, 'user', 'app' and 'env',
+    // which is useful for formatting the output of the log entries.
+    if (isset($context['layer']) && !in_array($context['layer'], array('user', 'app', 'env'))) {
+      $layer = $context['layer'];
+      throw new Exception("Unrecognized log layer \"$layer\"");
+    }
+
     switch ($level) {
       case L_DEBUG:
-        $self->monolog->addDebug($message);
+        $log->addDebug($message, $context);
         break;
       case L_INFO:
-        $self->monolog->addInfo($message);
+        $log->addInfo($message, $context);
         break;
       case L_WARNING:
-        $self->monolog->addWarning($message);
+        $log->addWarning($message, $context);
         break;
       case L_ERROR:
-        $self->monolog->addError($message);
+        $log->addError($message, $context);
         break;
       case L_CRITICAL:
-        $self->monolog->addCritical($message);
+        $log->addCritical($message, $context);
         break;
       case L_ALERT:
-        $self->monolog->addAlert($message);
+        $log->addAlert($message, $context);
         break;
     }
   }

--- a/controller/src/TrainingWheels/Plugin/Cloud9IDE/Cloud9IDEResource.php
+++ b/controller/src/TrainingWheels/Plugin/Cloud9IDE/Cloud9IDEResource.php
@@ -34,6 +34,7 @@ class Cloud9IDEResource extends SupervisorProcessResource {
    * Start the process.
    */
   public function create() {
+    parent::create();
     if ($this->getExists()) {
       throw new Exception("Attempting to create a Cloud9IDEResource that is already running.");
     }

--- a/controller/src/TrainingWheels/Plugin/Core/CoreLinuxEnv.php
+++ b/controller/src/TrainingWheels/Plugin/Core/CoreLinuxEnv.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace TrainingWheels\Plugin\Core;
+use Exception;
 
 class CoreLinuxEnv {
 

--- a/controller/src/TrainingWheels/Plugin/Drupal/Drupal.php
+++ b/controller/src/TrainingWheels/Plugin/Drupal/Drupal.php
@@ -2,6 +2,7 @@
 
 namespace TrainingWheels\Plugin\Drupal;
 use TrainingWheels\Plugin\PluginBase;
+use TrainingWheels\Log\Log;
 
 class Drupal extends PluginBase {
 
@@ -53,6 +54,7 @@ class Drupal extends PluginBase {
      * only one call will suffice for both.
      */
     $course->addObserver('afterUserResourcesSync', function($data) use ($settings_path) {
+      Log::log('Patching settings.php', L_INFO, 'actions', array('layer' => 'app', 'source' => 'DrupalPlugin'));
       $course_name = $data['course']->course_name;
       $target_name = $data['target']->getName();
 
@@ -70,6 +72,7 @@ class Drupal extends PluginBase {
      * Grant the group all access to files, which allows Apache to write.
      */
     $course->addObserver('afterUserResourcesCreate', function($data) use ($settings_path, $files_path) {
+      Log::log('Allow apache to write files', L_INFO, 'actions', array('layer' => 'app', 'source' => 'DrupalPlugin'));
       $db = $data['user']->resourceGet('drupal_db');
       $gitfiles = $data['user']->resourceGet('drupal_files');
 

--- a/controller/src/TrainingWheels/Plugin/GitFiles/GitFilesResource.php
+++ b/controller/src/TrainingWheels/Plugin/GitFiles/GitFilesResource.php
@@ -110,6 +110,7 @@ class GitFilesResource extends Resource {
    * Delete the files.
    */
   public function delete() {
+    parent::delete();
     if (!$this->getExists()) {
       throw new Exception("Attempting to delete a GitFilesResource that does not exist.");
     }
@@ -122,6 +123,7 @@ class GitFilesResource extends Resource {
    * Create the git clone in the correct place.
    */
   public function create() {
+    parent::create();
     if ($this->getExists()) {
       throw new Exception("Attempting to create a GitFilesResource that already exists.");
     }
@@ -134,6 +136,7 @@ class GitFilesResource extends Resource {
    * Sync to a target.
    */
   public function syncTo(GitFilesResource $target) {
+    parent::syncTo();
     $this->env->fileSyncUserFolder($this->user_name, $target->user_name, $this->course_name . '/');
   }
 }

--- a/controller/src/TrainingWheels/Plugin/MySQL/MySQLDatabaseResource.php
+++ b/controller/src/TrainingWheels/Plugin/MySQL/MySQLDatabaseResource.php
@@ -72,6 +72,7 @@ class MySQLDatabaseResource extends Resource {
    * Create the database.
    */
   public function create() {
+    parent::create();
     if ($this->getExists()) {
       throw new Exception("Attempting to create a MySQLDatabaseResource that already exists.");
     }
@@ -89,6 +90,7 @@ class MySQLDatabaseResource extends Resource {
    * Delete the database.
    */
   public function delete() {
+    parent::delete();
     if (!$this->getExists()) {
       throw new Exception("Attempting to delete a MySQLDatabaseResource that does not exist.");
     }
@@ -191,6 +193,7 @@ class MySQLDatabaseResource extends Resource {
    * Sync to a target.
    */
   public function syncTo(MySQLDatabaseResource $target) {
+    parent::syncTo();
     // Create a backup.
     if ($target->getExists()) {
       $target->dumpTo('tmp');

--- a/controller/src/TrainingWheels/Plugin/Supervisor/SupervisorProcessResource.php
+++ b/controller/src/TrainingWheels/Plugin/Supervisor/SupervisorProcessResource.php
@@ -36,6 +36,7 @@ abstract class SupervisorProcessResource extends Resource {
    * Stop the process, remove the config.
    */
   public function delete() {
+    parent::delete();
     if (!$this->getExists()) {
       throw new Exception("Attempting to delete a SupervisorProcessResource that does not exist.");
     }
@@ -50,6 +51,8 @@ abstract class SupervisorProcessResource extends Resource {
    * Start the process.
    */
   public function create() {
+    parent::create();
+
     // Make the conf file.
     $this->env->fileCreate("\"[program:$this->program]\ncommand=$this->command\ndirectory=$this->directory\nuser=$this->user_name\nautostart=true\nautorestart=true\n\"", $this->conf_path, 'root');
 
@@ -63,6 +66,7 @@ abstract class SupervisorProcessResource extends Resource {
    * Sync to a target. There's nothing to sync, just create the target's process.
    */
   public function syncTo($target) {
+    parent::syncTo();
     if (!$target->getExists()) {
       $target->create();
     }

--- a/controller/src/TrainingWheels/Resource/Resource.php
+++ b/controller/src/TrainingWheels/Resource/Resource.php
@@ -3,6 +3,7 @@
 namespace TrainingWheels\Resource;
 use TrainingWheels\Common\CachedObject;
 use TrainingWheels\Environment\Environment;
+use TrainingWheels\Log\Log;
 
 abstract class Resource extends CachedObject {
 
@@ -24,8 +25,6 @@ abstract class Resource extends CachedObject {
   // Whether it exists yet.
   protected $exists;
 
-  abstract public function create();
-  abstract public function delete();
   abstract public function getExists();
 
   /**
@@ -43,6 +42,34 @@ abstract class Resource extends CachedObject {
   }
 
   /**
+   * Helper to log messages from this class.
+   */
+  private function log($message, $level = L_INFO) {
+    Log::log($message, $level, 'actions', array('layer' => 'app', 'source' => $this->getType(), 'params' => $this->res_id));
+  }
+
+  /**
+   * Create resource.
+   */
+  public function create() {
+    $this->log('create()');
+  }
+
+  /**
+   * Delete resource.
+   */
+  public function delete() {
+    $this->log('delete()');
+  }
+
+  /**
+   * Sync resource to a target.
+   */
+  public function syncTo() {
+    $this->log('syncTo()');
+  }
+
+  /**
    * Return the short type of this plugin, e.g. 'MySQL'
    */
   public function getType() {
@@ -54,6 +81,7 @@ abstract class Resource extends CachedObject {
    * Get the information about the state of this resource.
    */
   public function get() {
+    $this->log('get()');
     $info = array(
       'type' => $this->getType(),
       'exists' => $this->getExists(),

--- a/controller/src/TrainingWheels/Store/DataStore.php
+++ b/controller/src/TrainingWheels/Store/DataStore.php
@@ -6,13 +6,22 @@ use MongoClient;
 
 class DataStore {
   private $db = NULL;
+  private $connection = NULL;
 
   /**
    * Constructor.
    */
   public function __construct($dbUrl) {
     $connection = new MongoClient($dbUrl);
+    $this->connection = $connection;
     $this->db = $connection->trainingwheels;
+  }
+
+  /**
+   * Get the MongoClient instance.
+   */
+  public function getConnection() {
+    return $this->connection;
   }
 
   /**
@@ -55,9 +64,12 @@ class DataStore {
   /**
    * Get all documents from a collection.
    */
-  public function findAll($collection) {
+  public function findAll($collection, $sort = NULL) {
     $output = array();
     $cursor = $this->db->$collection->find();
+    if ($sort) {
+      $cursor = $cursor->sort(array($sort => '1'));
+    }
     foreach ($cursor as $id => $value) {
       unset($value['_id']);
       $output[] = (object)$value;

--- a/controller/src/TrainingWheels/User/User.php
+++ b/controller/src/TrainingWheels/User/User.php
@@ -4,6 +4,7 @@ namespace TrainingWheels\User;
 use TrainingWheels\Common\CachedObject;
 use TrainingWheels\Common\Util;
 use TrainingWheels\Environment\Environment;
+use TrainingWheels\Log\Log;
 use Exception;
 
 class User extends CachedObject {
@@ -50,6 +51,13 @@ class User extends CachedObject {
   }
 
   /**
+   * Helper to log messages from this class.
+   */
+  private function log($message, $params = '') {
+    Log::log($message, L_INFO, 'actions', array('layer' => 'app', 'source' => 'User', 'params' => "user=" . $this->getName() . ' ' . $params));
+  }
+
+  /**
    * Get the name.
    */
   public function getName() {
@@ -63,6 +71,7 @@ class User extends CachedObject {
     if ($this->getExists()) {
       throw new Exception("Attempting to create a user that already exists");
     }
+    $this->log('create()');
     $this->exists = TRUE;
     $this->password = Util::passwdGen();
     $this->env->userCreate($this->user_name, $this->password);
@@ -83,6 +92,7 @@ class User extends CachedObject {
         $res->delete();
       }
     }
+    $this->log('delete()');
     $this->env->userDelete($this->user_name);
     $this->exists = FALSE;
     $this->password = FALSE;
@@ -104,6 +114,7 @@ class User extends CachedObject {
    * Get the resources.
    */
   public function resourcesGetAll() {
+    $this->log('resourcesGetAll()');
     return $this->resources;
   }
 
@@ -111,6 +122,7 @@ class User extends CachedObject {
    * Get a resource.
    */
   public function resourceGet($name) {
+    $this->log('resourceGet', "res=$name");
     return isset($this->resources[$name]) ? $this->resources[$name] : FALSE;
   }
 
@@ -118,6 +130,7 @@ class User extends CachedObject {
    * Create the resources.
    */
   public function resourcesCreate($resources) {
+    $this->log('resourcesCreate', "res=$resources");
     if ($resources == '*' || $resources == array('*')) {
       foreach ($this->resources as $res) {
         $res->create();
@@ -139,6 +152,7 @@ class User extends CachedObject {
    * Delete the resources.
    */
   public function resourcesDelete($resources) {
+    $this->log('resourcesDelete');
     if ($resources == '*' || $resources == array('*')) {
       foreach ($this->resources as $res) {
         $res->delete();
@@ -160,6 +174,7 @@ class User extends CachedObject {
    * Sync resources to another user.
    */
   public function syncTo(User $target, $resources) {
+    $this->log('syncTo', "target=" . $target->getName());
     $target_resources = $target->resourcesGetAll();
 
     foreach ($this->resources as $key => $res) {
@@ -203,6 +218,7 @@ class User extends CachedObject {
    *   if $full is FALSE, skip resources.
    */
   public function get($full = TRUE) {
+    $this->log('get()');
     if ($this->getExists()) {
       $user = array(
         'user_name' => $this->user_name,

--- a/controller/web/css/logs.css
+++ b/controller/web/css/logs.css
@@ -1,0 +1,45 @@
+table#logs-main {
+  border-width: 1px;
+  border-spacing: 0px;
+  border-color: black;
+  border-style: solid;
+
+  border-collapse:separate;
+  border-spacing:0px 2px;
+}
+
+thead > tr {
+  background-color: #AEC5DF;
+}
+
+th {
+  text-align: left;
+}
+
+td.log-item {
+  padding: 3px;
+}
+
+td.log-datetime, td.log-source, td.log-message {
+  white-space: nowrap;
+}
+
+tr.log-layer-user {
+  background-color: #F88956;
+}
+
+tr.log-layer-app.log-level-debug {
+  background-color: #EEEBCA;
+}
+
+tr.log-layer-app.log-level-info {
+  background-color: #D4CD8A;
+}
+
+tr.log-layer-env {
+  background-color: #D4DEBD;
+}
+
+tr.log-level-warning {
+  background-color: #E87B80;
+}

--- a/controller/web/logs.twig
+++ b/controller/web/logs.twig
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Training Wheels Controller</title>
+  <meta name="description" content="Training Wheels is an application for managing training environments.">
+  <meta name="author" content="Four Kitchens">
+  <link rel="apple-touch-icon" href="touch-icon-iphone.png" />
+  <link rel="apple-touch-icon" sizes="72x72" href="touch-icon-ipad.png" />
+  <link rel="apple-touch-icon" sizes="114x114" href="touch-icon-iphone-retina.png" />
+  <link rel="apple-touch-icon" sizes="144x144" href="touch-icon-ipad-retina.png" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+  <link href="/css/logs.css" type="text/css" rel="stylesheet" />
+</head>
+<body>
+  {{ logs|raw }}
+</body>
+</html>


### PR DESCRIPTION
The text logs were really slowing me down, as I couldn't figure out easily what was happening. So I made this web interface (at /logs) that shows a very pretty output of the logs. These entries are now saved into MongoDB:

![Training Wheels Controller](https://f.cloud.github.com/assets/453297/214538/2f9b3e98-842d-11e2-8de1-648c4dbe5e6f.png)

This also provides two new console commands for debugging: `tw mongo:cli` will immediately drop you into the Mongo CLI using the TW database and credentials (similar to `drush sql-cli`, and `tw log:clear` will clear all logs from the MongoDB.

It also adds a /logout link and refactors how the Silex user session checking works to facilitate other silex paths redirecting back to /login if required.

This pull request should be recreated with master as the target, rather than merging this particular one. The order of merges to master should be:
1. TW-95-ssh-conn
2. fix-bug-cloud9-res
3. **better-loggin**
4. caching
