### PR TITLE
Caching system

### DIFF
--- a/controller/cli/tw.php
+++ b/controller/cli/tw.php
@@ -47,6 +47,7 @@ use TrainingWheels\Console\UserRetrieve;
 use TrainingWheels\Console\KeyCreate;
 use TrainingWheels\Console\LogClear;
 use TrainingWheels\Console\MongoCLI;
+use TrainingWheels\Console\ObjectCacheClear;
 
 $console = new Application();
 $console->add(new CourseProvision($app['tw.job_factory']));
@@ -59,5 +60,6 @@ $console->add(new ResourceSync($app['tw.job_factory']));
 $console->add(new KeyCreate($app['tw.config']));
 $console->add(new LogClear($app['tw.log']));
 $console->add(new MongoCLI($app['tw.config']));
+$console->add(new ObjectCacheClear($app['tw.datastore']));
 
 $console->run();

--- a/controller/src/TrainingWheels/Common/CachedObject.php
+++ b/controller/src/TrainingWheels/Common/CachedObject.php
@@ -1,6 +1,8 @@
 <?php
 
 namespace TrainingWheels\Common;
+use TrainingWheels\Store\DataStore;
+use TrainingWheels\Log\Log;
 use Exception;
 
 abstract class CachedObject {
@@ -8,18 +10,45 @@ abstract class CachedObject {
   private $id;
   private $properties;
 
+  // Reference to the data store.
+  protected $data;
+
+  /**
+   * Helper to log messages from this class.
+   */
+  private function log($message, $params, $level = L_DEBUG) {
+    Log::log($message, $level, 'actions', array('layer' => 'app', 'source' => 'CachedObject', 'params' => $params));
+  }
+
   /**
    * Constructor.
    */
-  public function __construct() {
+  public function __construct(DataStore $data) {
+    $this->data = $data;
     $this->properties = array();
   }
 
   /**
-   * Build this object.
+   * Destructor. Save this object to the cache if the ID has been set.
+   */
+  public function __destruct() {
+    if ($this->id) {
+      $this->cacheSave();
+    }
+    else {
+      $this->log('Unsaved cache object', "id=$this->id", L_WARNING);
+    }
+  }
+
+  /**
+   * Build this object. This should be called from the child class' constructor,
+   * after registering the required properties.
    */
   protected function cacheBuild($id) {
-    $this->id = 'tw-' . $id;
+    if (empty($id)) {
+      throw new Exception("Cannot build cache object without a provided ID.");
+    }
+    $this->id = $id;
     $this->cacheFetch();
   }
 
@@ -33,26 +62,45 @@ abstract class CachedObject {
   /**
    * Save the current object back to the cache.
    */
-  protected function cacheSave() {
-    $data = array();
+  private function cacheSave() {
+    $cache_entry = array(
+      'id' => $this->id,
+      'data' => array(),
+    );
+
     foreach ($this->properties as $prop) {
-      $data[$prop] = $this->$prop;
+      if (isset($this->$prop)) {
+        $cache_entry['data'][$prop] = $this->$prop;
+      }
     }
-    //cache_set($this->id, $data, 'cache');
+
+    $this->log('Cache save', json_encode($cache_entry));
+    $this->data->remove('cache', array('id' => $this->id));
+    $this->data->insert('cache', $cache_entry, FALSE);
   }
 
   /**
-   * Load properties from the cache.
+   * Load properties from the cache and apply them to this object.
    */
   private function cacheFetch() {
-    //$data = cache_get($this->id, 'cache');;
-    $data = NULL;
-    if ($data) {
+    $cache_entry = $this->data->find('cache', array('id' => $this->id));
+    if ($cache_entry) {
+      unset($cache_entry['_id']);
+      $this->log('Item hit', json_encode($cache_entry));
+
       foreach ($this->properties as $prop) {
-        if (isset($data->data[$prop]) && !empty($data->data[$prop])) {
-          $this->$prop = $data->data[$prop];
+        $this->log('Entry lookup', $prop);
+        if (isset($cache_entry['data'][$prop])) {
+          $this->$prop = $cache_entry['data'][$prop];
+          $this->log('Entry hit', json_encode(array($prop => $this->$prop)));
+        }
+        else {
+          $this->log('Entry miss', $prop);
         }
       }
+    }
+    else {
+      $this->log('Item miss', "id=$this->id");
     }
   }
 }

--- a/controller/src/TrainingWheels/Console/ObjectCacheClear.php
+++ b/controller/src/TrainingWheels/Console/ObjectCacheClear.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace TrainingWheels\Console;
+use TrainingWheels\Log\Log;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Exception;
+
+class ObjectCacheClear extends Command {
+  private $data;
+
+  public function __construct($data) {
+    parent::__construct();
+    $this->data = $data;
+  }
+
+  protected function configure() {
+    $this->setName('objectcache:clear')
+         ->setDescription('Clear the object cache.');
+  }
+
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    Log::log('ObjectCacheClear', L_INFO, 'actions', array('layer' => 'user', 'source' => 'CLI'));
+    $this->data->remove('cache', array());
+    $output->writeln('<info>Object cache cleared.</info>');
+  }
+}

--- a/controller/src/TrainingWheels/Course/Course.php
+++ b/controller/src/TrainingWheels/Course/Course.php
@@ -4,6 +4,7 @@ namespace TrainingWheels\Course;
 use TrainingWheels\Log\Log;
 use TrainingWheels\Common\Observable;
 use TrainingWheels\User\User;
+use TrainingWheels\Store\DataStore;
 use Exception;
 
 class Course extends Observable {
@@ -21,6 +22,13 @@ class Course extends Observable {
 
   // Resource config.
   protected $resource_config;
+
+  // Reference to the DataStore.
+  protected $data;
+
+  public function __construct(DataStore $data) {
+    $this->data = $data;
+  }
 
   public function setPlugins(array $plugins) {
     $this->plugins = $plugins;
@@ -50,8 +58,8 @@ class Course extends Observable {
    */
   protected function userFactory($user_name) {
     $user_id = $this->course_id . '-' . $user_name;
-    $user_obj = new User($this->env, $user_name, $user_id);
-    Log::log('Building user', L_DEBUG, 'actions', array('layer' => 'app', 'source' => 'UserFactory', 'params' => 'user_id=' . $user_id));
+    $user_obj = new User($this->env, $this->data, $user_name, $user_id);
+    $this->log('Building user', $user_id, 'UserFactory', L_DEBUG);
 
     // Each user object must receive resource objects too. These are created
     // based on the course's resources config.
@@ -63,8 +71,8 @@ class Course extends Observable {
       }
       $plugin = $this->plugins[$res['plugin']];
 
-      $user_res[$key] = $plugin->resourceFactory($res['type'], $this->env, $res['title'], $user_name, $this->course_name, $user_res_id, $res);
-      Log::log('Building resource', L_DEBUG, 'actions', array('layer' => 'app', 'source' => 'UserFactory', 'params' => 'res_id=' . $user_res_id));
+      $user_res[$key] = $plugin->resourceFactory($res['type'], $this->env, $this->data, $res['title'], $user_name, $this->course_name, $user_res_id, $res);
+      $this->log('Building resource', $user_res_id, 'UserFactory', L_DEBUG);
     }
     $user_obj->resources = $user_res;
 

--- a/controller/src/TrainingWheels/Course/CourseFactory.php
+++ b/controller/src/TrainingWheels/Course/CourseFactory.php
@@ -45,7 +45,7 @@ class CourseFactory extends Factory {
       }
 
       // Create a Course object.
-      $course = new Course();
+      $course = new Course($this->data);
       $course->course_id = $course_id;
       $course->title = $params['title'];
       $course->description = $params['description'];

--- a/controller/src/TrainingWheels/Plugin/Cloud9IDE/Cloud9IDEResource.php
+++ b/controller/src/TrainingWheels/Plugin/Cloud9IDE/Cloud9IDEResource.php
@@ -4,6 +4,7 @@ namespace TrainingWheels\Plugin\Cloud9IDE;
 use TrainingWheels\Resource\Resource;
 use TrainingWheels\Plugin\Supervisor\SupervisorProcessResource;
 use TrainingWheels\Environment\Environment;
+use TrainingWheels\Store\DataStore;
 use Exception;
 
 class Cloud9IDEResource extends SupervisorProcessResource {
@@ -11,8 +12,9 @@ class Cloud9IDEResource extends SupervisorProcessResource {
   /**
    * Constructor.
    */
-  public function __construct(Environment $env, $title, $user_name, $course_name, $res_id, $data) {
-    parent::__construct($env, $title, $user_name, $course_name, $res_id, $data);
+  public function __construct(Environment $env, DataStore $data, $title, $user_name, $course_name, $res_id, $config) {
+    parent::__construct($env, $data, $title, $user_name, $course_name, $res_id, $config);
+    $this->cacheBuild($res_id);
   }
 
   /**
@@ -34,7 +36,6 @@ class Cloud9IDEResource extends SupervisorProcessResource {
    * Start the process.
    */
   public function create() {
-    parent::create();
     if ($this->getExists()) {
       throw new Exception("Attempting to create a Cloud9IDEResource that is already running.");
     }

--- a/controller/src/TrainingWheels/Plugin/GitFiles/GitFilesResource.php
+++ b/controller/src/TrainingWheels/Plugin/GitFiles/GitFilesResource.php
@@ -3,6 +3,7 @@
 namespace TrainingWheels\Plugin\GitFiles;
 use TrainingWheels\Resource\Resource;
 use TrainingWheels\Environment\Environment;
+use TrainingWheels\Store\DataStore;
 use Exception;
 
 class GitFilesResource extends Resource {
@@ -16,17 +17,17 @@ class GitFilesResource extends Resource {
   /**
    * Constructor.
    */
-  public function __construct(Environment $env, $title, $user_name, $course_name, $res_id, $data) {
-    parent::__construct($env, $title, $user_name, $course_name, $res_id);
+  public function __construct(Environment $env, DataStore $data, $title, $user_name, $course_name, $res_id, $config) {
+    parent::__construct($env, $data, $title, $user_name, $course_name, $res_id);
 
-    $this->subdir = $data['subdir'];
+    $this->subdir = $config['subdir'];
     $this->fullpath = "/twhome/$user_name/$course_name";
     if ($this->subdir) {
       $this->fullpath = $this->fullpath . '/' . $this->subdir;
     }
-    $this->repo = $data['repo_url'];
+    $this->repo = $config['repo_url'];
     $this->course_name = $course_name;
-    $this->default_branch = $data['default_branch'];
+    $this->default_branch = $config['default_branch'];
 
     $this->cacheBuild($res_id);
   }
@@ -99,9 +100,8 @@ class GitFilesResource extends Resource {
    * Do the files exist in the environment?
    */
   public function getExists() {
-    if (!$this->exists) {
+    if (!isset($this->exists)) {
       $this->exists = $this->env->dirExists($this->fullpath);
-      $this->cacheSave();
     }
     return $this->exists;
   }
@@ -116,7 +116,6 @@ class GitFilesResource extends Resource {
     }
     $this->env->dirDelete($this->fullpath);
     $this->exists = FALSE;
-    $this->cacheSave();
   }
 
   /**
@@ -129,7 +128,6 @@ class GitFilesResource extends Resource {
     }
     $this->exists = TRUE;
     $this->env->gitRepoClone($this->user_name, $this->repo, $this->fullpath, $this->default_branch);
-    $this->cacheSave();
   }
 
   /**
@@ -138,5 +136,6 @@ class GitFilesResource extends Resource {
   public function syncTo(GitFilesResource $target) {
     parent::syncTo();
     $this->env->fileSyncUserFolder($this->user_name, $target->user_name, $this->course_name . '/');
+    $target->setExists(TRUE);
   }
 }

--- a/controller/src/TrainingWheels/Plugin/MySQL/MySQLDatabaseResource.php
+++ b/controller/src/TrainingWheels/Plugin/MySQL/MySQLDatabaseResource.php
@@ -4,6 +4,7 @@ namespace TrainingWheels\Plugin\MySQL;
 use TrainingWheels\Resource\Resource;
 use TrainingWheels\Common\Util;
 use TrainingWheels\Environment\Environment;
+use TrainingWheels\Store\DataStore;
 use Exception;
 
 class MySQLDatabaseResource extends Resource {
@@ -17,10 +18,10 @@ class MySQLDatabaseResource extends Resource {
   /**
    * Constructor.
    */
-  public function __construct(Environment $env, $title, $user_name, $course_name, $res_id, $data) {
-    parent::__construct($env, $title, $user_name, $course_name, $res_id);
+  public function __construct(Environment $env, DataStore $data, $title, $user_name, $course_name, $res_id, $config) {
+    parent::__construct($env, $data, $title, $user_name, $course_name, $res_id);
     $this->course_name = $course_name;
-    $this->dump_path = "/twhome/$user_name/$course_name/" . $data['dump_path'];
+    $this->dump_path = "/twhome/$user_name/$course_name/" . $config['dump_path'];
 
     $this->cachePropertiesAdd(array('db_name', 'mysql_username', 'mysql_password'));
     $this->cacheBuild($res_id);
@@ -61,9 +62,8 @@ class MySQLDatabaseResource extends Resource {
    * Return bool for whether the database exists in the environment.
    */
   public function getExists() {
-    if (!$this->exists) {
+    if (!isset($this->exists)) {
       $this->exists = $this->env->mySQLDBExists($this->genSafeDBName());
-      $this->cacheSave();
     }
     return $this->exists;
   }
@@ -83,7 +83,6 @@ class MySQLDatabaseResource extends Resource {
 
     $this->env->mySQLUserDBCreate($this->mysql_username, $this->mysql_password, $this->db_name, $this->dump_path);
     $this->credentialsCreate();
-    $this->cacheSave();
   }
 
   /**
@@ -96,11 +95,10 @@ class MySQLDatabaseResource extends Resource {
     }
     $this->env->mySQLUserDBDelete($this->getUserName(), $this->getDBName());
 
-    $this->mysql_password = FALSE;
-    $this->mysql_username = FALSE;
-    $this->db_name = FALSE;
+    unset($this->mysql_password);
+    unset($this->mysql_username);
+    unset($this->db_name);
     $this->exists = FALSE;
-    $this->cacheSave();
   }
 
   /**
@@ -142,7 +140,6 @@ class MySQLDatabaseResource extends Resource {
   public function getDBName() {
     if (!isset($this->db_name)) {
       $this->db_name = $this->genSafeDBName();
-      $this->cacheSave();
     }
     return $this->db_name;
   }
@@ -152,9 +149,8 @@ class MySQLDatabaseResource extends Resource {
    * be done on construction.
    */
   public function getUserName() {
-    if (empty($this->mysql_username)) {
+    if (!isset($this->mysql_username)) {
       $this->mysql_username = $this->genSafeDBName();
-      $this->cacheSave();
     }
     return $this->mysql_username;
   }
@@ -163,14 +159,13 @@ class MySQLDatabaseResource extends Resource {
    * Lazy load the password from the credentials.
    */
   public function getPasswd() {
-    if (empty($this->mysql_password)) {
+    if (!isset($this->mysql_password)) {
       if ($this->env->fileExists("/twhome/$this->user_name/.my.cnf")) {
         $cnf = $this->env->fileGetContents("/twhome/$this->user_name/.my.cnf");
 
         if (!empty($cnf)) {
           $ini = parse_ini_string($cnf);
           $this->mysql_password = $ini['pass'];
-          $this->cacheSave();
         }
       }
     }

--- a/controller/src/TrainingWheels/Plugin/PluginBase.php
+++ b/controller/src/TrainingWheels/Plugin/PluginBase.php
@@ -18,14 +18,14 @@ abstract class PluginBase {
   /**
    * Get the resource object for this plugin.
    */
-  public function resourceFactory($type, $env, $title, $user_name, $course_name, $res_id, $data) {
+  public function resourceFactory($type, $env, $data, $title, $user_name, $course_name, $res_id, $config) {
     $classes = $this->getResourceClasses();
     if (!$classes) {
-      $type = $this->getType();
-      throw new Exception("The plugin type \"$type\" does not provide resources");
+      $plugin_type = $this->getType();
+      throw new Exception("The plugin type \"$plugin_type\" does not provide resources");
     }
     $class = $classes[$type];
-    $obj = new $class($env, $title, $user_name, $course_name, $res_id, $data);
+    $obj = new $class($env, $data, $title, $user_name, $course_name, $res_id, $config);
     return $obj;
   }
 

--- a/controller/src/TrainingWheels/Plugin/Supervisor/SupervisorProcessResource.php
+++ b/controller/src/TrainingWheels/Plugin/Supervisor/SupervisorProcessResource.php
@@ -3,6 +3,7 @@
 namespace TrainingWheels\Plugin\Supervisor;
 use TrainingWheels\Resource\Resource;
 use TrainingWheels\Environment\Environment;
+use TrainingWheels\Store\DataStore;
 use Exception;
 
 abstract class SupervisorProcessResource extends Resource {
@@ -15,8 +16,8 @@ abstract class SupervisorProcessResource extends Resource {
   /**
    * Constructor.
    */
-  public function __construct(Environment $env, $title, $user_name, $course_name, $res_id, $data) {
-    parent::__construct($env, $title, $user_name, $course_name, $res_id);
+  public function __construct(Environment $env, DataStore $data, $title, $user_name, $course_name, $res_id, $config) {
+    parent::__construct($env, $data, $title, $user_name, $course_name, $res_id);
     $this->program = $res_id;
     $this->conf_path = "/etc/supervisor/conf.d/$this->program.conf";
   }
@@ -25,9 +26,8 @@ abstract class SupervisorProcessResource extends Resource {
    * Is the process already running?
    */
   public function getExists() {
-    if (!$this->exists) {
+    if (!isset($this->exists)) {
       $this->exists = $this->env->supervisorProgramIsRunning($this->program);
-      $this->cacheSave();
     }
     return $this->exists;
   }
@@ -44,7 +44,6 @@ abstract class SupervisorProcessResource extends Resource {
     $this->env->fileDelete($this->conf_path);
     $this->env->supervisorUpdateConfig();
     $this->exists = FALSE;
-    $this->cacheSave();
   }
 
   /**
@@ -60,6 +59,7 @@ abstract class SupervisorProcessResource extends Resource {
     // defined with autostart=true above, it will start as soon as the config
     // is read in.
     $this->env->supervisorUpdateConfig();
+    $this->exists = TRUE;
   }
 
   /**
@@ -70,5 +70,12 @@ abstract class SupervisorProcessResource extends Resource {
     if (!$target->getExists()) {
       $target->create();
     }
+  }
+
+  /**
+   * Get info.
+   */
+  public function get() {
+    return parent::get();
   }
 }

--- a/controller/src/TrainingWheels/Resource/Resource.php
+++ b/controller/src/TrainingWheels/Resource/Resource.php
@@ -4,6 +4,7 @@ namespace TrainingWheels\Resource;
 use TrainingWheels\Common\CachedObject;
 use TrainingWheels\Environment\Environment;
 use TrainingWheels\Log\Log;
+use TrainingWheels\Store\DataStore;
 
 abstract class Resource extends CachedObject {
 
@@ -25,19 +26,20 @@ abstract class Resource extends CachedObject {
   // Whether it exists yet.
   protected $exists;
 
-  abstract public function getExists();
+  // The type of resource.
+  private $type;
 
   /**
    * Constructor.
    */
-  public function __construct(Environment $env, $title, $user_name, $course_name, $res_id) {
+  public function __construct(Environment $env, DataStore $data, $title, $user_name, $course_name, $res_id) {
     $this->env = $env;
     $this->title = $title;
     $this->user_name = $user_name;
     $this->course_name = $course_name;
     $this->res_id = $res_id;
 
-    parent::__construct();
+    parent::__construct($data);
     $this->cachePropertiesAdd(array('exists'));
   }
 
@@ -46,6 +48,14 @@ abstract class Resource extends CachedObject {
    */
   private function log($message, $level = L_INFO) {
     Log::log($message, $level, 'actions', array('layer' => 'app', 'source' => $this->getType(), 'params' => $this->res_id));
+  }
+
+  /**
+   * Set whether this resource exists.
+   */
+  public function setExists($exists) {
+    $this->log('setExists()', L_DEBUG);
+    $this->exists = $exists;
   }
 
   /**
@@ -73,8 +83,11 @@ abstract class Resource extends CachedObject {
    * Return the short type of this plugin, e.g. 'MySQL'
    */
   public function getType() {
-    $pieces = explode('\\', get_class($this));
-    return $pieces[count($pieces)-1];
+    if (!isset($this->type)) {
+      $pieces = explode('\\', get_class($this));
+      $this->type = $pieces[count($pieces)-1];
+    }
+    return $this->type;
   }
 
   /**

--- a/controller/src/TrainingWheels/Store/DataStore.php
+++ b/controller/src/TrainingWheels/Store/DataStore.php
@@ -86,9 +86,3 @@ class DataStore {
     return $this->db->$collection->remove($criteria, $options);
   }
 }
-
-
-
-
-
-


### PR DESCRIPTION
Training Wheels is seriously slow when you have > +-10 users, and twice as bad as that when the connection is over SSH. To mitigate this, this branch implements a MongoDB object cache, similar to an ORM in some ways, but simpler. 

The basic idea is that any object can extend CachedObject, and in it's constructor, provide an array of properties that must be saved when the object is cached (saving back to the cache happens in the destructor). 

``` php
$this->cachePropertiesAdd(array('exists', 'password', 'env_user_id'));
$this->cacheBuild($user_id);
```

This call to the parent class `cacheBuild` will fetch the id from Mongo, and populate any properties on the current object with data that it finds. For example, then we can create a `MySQLDatabaseResource` and call `->getPasswd()` on it, without it actually retrieving the password using the environment. 

The logs were very useful in developing this, so check 'em out.

This pull request should be recreated with master as the target, rather than merging this particular one. The order of merges to master should be:
1. TW-95-ssh-conn
2. fix-bug-cloud9-res
3. better-loggin
4. **caching**
